### PR TITLE
Fix for new discourse; use new lock; typo

### DIFF
--- a/assets/javascripts/auth0.js
+++ b/assets/javascripts/auth0.js
@@ -31,7 +31,7 @@
     }, 300);
   });
   
-  var LoginController = Discourse.__container__.lookup('controller:login');
+  var LoginController = require('discourse/controllers/login').default;
   LoginController.reopen({
     authenticationComplete: function () {
       if (lock) {

--- a/assets/javascripts/auth0.js
+++ b/assets/javascripts/auth0.js
@@ -9,7 +9,7 @@
 
   var lock;
 
-  var script_url = '//cdn.auth0.com/js/lock-7.9.js';
+  var script_url = '//cdn.auth0.com/js/lock-8.0.js';
 
   appendScript(script_url, function () {
     var checkInterval = setInterval(function () {

--- a/assets/javascripts/auth0.js
+++ b/assets/javascripts/auth0.js
@@ -30,8 +30,9 @@
 
     }, 300);
   });
-
-  Discourse.LoginController.reopen({
+  
+  var LoginController = Discourse.__container__.lookup('controller:login');
+  LoginController.reopen({
     authenticationComplete: function () {
       if (lock) {
         lock.hide();
@@ -39,8 +40,9 @@
       return this._super.apply(this, arguments);
     }
   });
-
-  Discourse.ApplicationRoute.reopen({
+  
+  var ApplicationRoute = require('discourse/routes/application').default;
+  ApplicationRoute.reopen({
     actions: {
       showLogin: function() {
         if (!Discourse.SiteSettings.auth0_client_id || Discourse.SiteSettings.auth0_connection !== '') {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,6 @@
 en:
   site_settings:
-    auth0_domain: 'You auth0 domain. This is tipically <account>.auth0.com.'
+    auth0_domain: 'You auth0 domain. This is typically <account>.auth0.com.'
     auth0_client_id: 'Your auth0 client id. Find it on the application settings on the Auth0 dashboard.'
     auth0_client_secret: 'Your auth0 client secret. Find it on the application settings on the Auth0 dashboard.'
     auth0_callback_url: 'The url auth0 will redirect after authentication. Tipically https://your discourse url/auth/auth0/callback'


### PR DESCRIPTION
This patch addresses several issues. The most serious is that the auth0 discourse plugin was failing on new installations due to (I think) ember.js changes in later Discourse versions. The patches to auth0.js fix this, but should be tested against previous versions since conditional logic may be needed.

The other two changes are minor: (1) upgrading to Auth0 Lock 8.0 and (2) fixing a typo in the settings page.